### PR TITLE
Mejora: Pipeline_2.0 con descarga robusta y referencia RefSeq verificada (HTTPS+MD5)

### DIFF
--- a/src/Descarga_gen.py
+++ b/src/Descarga_gen.py
@@ -2,6 +2,10 @@ from Bio import SeqIO
 import os
 import glob
 
+# ===========================================================
+# FUNCIÓN: Identificar el genoma de referencia
+# ===========================================================
+
 def identificar_genoma_referencia(bioproject_dir):
     """
     Analiza las secuencias descargadas y identifica el genoma de referencia
@@ -150,6 +154,10 @@ def identificar_genoma_referencia(bioproject_dir):
     print(f"\n Genoma de referencia guardado en: {genoma_file}")
     
     return mejor_candidato['info']
+
+# ===========================================================
+# FUNCIÓN: Analizar estructura del genoma
+# ===========================================================
 
 def analizar_estructura_genoma(genoma_info):
     """

--- a/src/Pipeline_2.0.py
+++ b/src/Pipeline_2.0.py
@@ -8,7 +8,7 @@ import shutil
 # ===============================
 # CONFIGURATION
 # ===============================
-Entrez.email = "zyanyava@lcg.unam.mx"  # Replace with your email
+Entrez.email = "marinams@lcg.unam.mx"  # Replace with your email
 
 # SRA project ID for GSE160968
 srp_id = "SRP291413"

--- a/src/Pipeline_2.0.py
+++ b/src/Pipeline_2.0.py
@@ -38,8 +38,8 @@ strain_hint = "AQSCr"                      # Nombre de cepa (opcional pero útil
 bioproject_hint = "PRJNA341863"                     # Ejemplo: "PRJNA341863" (opcional) o NONE
 
 # Rutas del SRA Toolkit (editar según tu sistema)
-prefetch_path = "/usr/local/bin/prefetch"        # En Windows: r"C:\\Program Files\\sratoolkit\\bin\\prefetch.exe"
-fasterq_dump_path = "/usr/local/bin/fasterq-dump"
+prefetch_path = "prefetch"        # Usamos un ambiente conda /home/ismadlsh/.conda/envs/bio_informatics
+fasterq_dump_path = "fasterq-dump"
 
 # ============================================================================
 # CREAR ESTRUCTURA DE DIRECTORIOS
@@ -58,7 +58,7 @@ print(f" Directorios creados en: {output_dir}")
 # ============================================================================
 # 1. OBTENER LOS SRR IDs DEL PROYECTO SRA
 # ============================================================================
-print(f"\n📡 Obteniendo IDs SRR del proyecto SRA: {srp_id}")
+print(f"\n Obteniendo IDs SRR del proyecto SRA: {srp_id}")
 
 handle = Entrez.esearch(db="sra", term=srp_id)
 record = Entrez.read(handle)

--- a/src/Pipeline_2.0.py
+++ b/src/Pipeline_2.0.py
@@ -1,115 +1,156 @@
+"""
+Pipeline 2.0 Descarga automatizada de datos RNA-seq y genoma de referencia
+para *Klebsiella* sp. AQSCr durante la exposición a Cr(VI).
+
+Este script combina la descarga de datos de secuenciación desde SRA
+con la obtención estandarizada del genoma de referencia mediante el
+módulo `descarga_genoma_referencia.py`.
+
+Características:
+    • Descarga automática de los archivos SRR desde un proyecto SRA.
+    • Conversión a formato FASTQ mediante SRA Toolkit.
+    • Búsqueda y descarga del mejor genoma de referencia (RefSeq preferido).
+    • Descompresión automática de archivos FASTA y GFF.
+    • Compatible con Linux, macOS y Windows.
+"""
+
 import os
-from Bio import Entrez
-import subprocess
-import urllib.request
 import gzip
 import shutil
+import subprocess
+from Bio import Entrez
+from descarga_genoma_referencia import fetch_reference_package
 
-# ===============================
-# CONFIGURATION
-# ===============================
-Entrez.email = "marinams@lcg.unam.mx"  # Replace with your email
+# ============================================================================
+# CONFIGURACIÓN GENERAL
+# ============================================================================
+Entrez.email = "marinams@lcg.unam.mx"  # NCBI lo requiere
 
-# SRA project ID for GSE160968
+# Identificador del proyecto SRA (contiene los experimentos RNA-seq)
 srp_id = "SRP291413"
 
+# Carpeta principal del proyecto
 output_dir = "Klebsiella_AqSCr_RNAseq"
 
-# Genome URLs (strain AqSCr / SAMN05730075)
-fasta_url = "https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/008/452/795/GCA_008452795.1_MJDM00000000/GCA_008452795.1_MJDM00000000_genomic.fna.gz"
-gff_url = "https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/008/452/795/GCA_008452795.1_MJDM00000000/GCA_008452795.1_MJDM00000000_genomic.gff.gz"
+# Parámetros para descubrir el genoma de referencia
+organism_query = "Klebsiella sp. AQSCr"   # Nombre del organismo
+strain_hint = "AQSCr"                      # Nombre de cepa (opcional pero útil)
+bioproject_hint = "PRJNA341863"                     # Ejemplo: "PRJNA341863" (opcional) o NONE
 
-# Full paths to SRA Toolkit executables
-prefetch_path = r"C:\Program Files\sratoolkit.3.2.1-win64\bin\prefetch.exe"        # <-- UPDATE THIS
-fasterq_dump_path = r"C:\Program Files\sratoolkit.3.2.1-win64\bin\fasterq-dump.exe" # <-- UPDATE THIS
+# Rutas del SRA Toolkit (editar según tu sistema)
+prefetch_path = "/usr/local/bin/prefetch"        # En Windows: r"C:\\Program Files\\sratoolkit\\bin\\prefetch.exe"
+fasterq_dump_path = "/usr/local/bin/fasterq-dump"
 
-# ===============================
-# CREATE DIRECTORY STRUCTURE
-# ===============================
+# ============================================================================
+# CREAR ESTRUCTURA DE DIRECTORIOS
+# ============================================================================
 dirs = {
     "raw_sra": os.path.join(output_dir, "raw_sra"),
     "fastq": os.path.join(output_dir, "fastq"),
-    "genome": os.path.join(output_dir, "genome")
+    "genome": os.path.join(output_dir, "genome"),
 }
 
 for d in dirs.values():
     os.makedirs(d, exist_ok=True)
 
-print(f"Created project directories in {output_dir}")
+print(f" Directorios creados en: {output_dir}")
 
-# ===============================
-# 1. GET SRR IDs FROM SRA PROJECT
-# ===============================
-print(f"Fetching SRR IDs from SRA project {srp_id}...")
+# ============================================================================
+# 1. OBTENER LOS SRR IDs DEL PROYECTO SRA
+# ============================================================================
+print(f"\n📡 Obteniendo IDs SRR del proyecto SRA: {srp_id}")
 
 handle = Entrez.esearch(db="sra", term=srp_id)
 record = Entrez.read(handle)
 handle.close()
-
-sra_ids = record['IdList']
+sra_ids = record["IdList"]
 
 srr_ids = []
 for sra_id in sra_ids:
     summary_handle = Entrez.esummary(db="sra", id=sra_id)
     summary = Entrez.read(summary_handle)
     summary_handle.close()
-    runs = summary[0]['Runs']  # XML-like string
-    # Extract SRR accession numbers
-    for run in runs.split(','):
+    runs = summary[0]["Runs"]
+    for run in runs.split(","):
         start = run.find('acc="') + len('acc="')
         end = run.find('"', start)
         srr_ids.append(run[start:end])
 
 if not srr_ids:
-    print("No SRR IDs found. Check the SRP ID.")
+    print("  No se encontraron SRR IDs. Verifica el ID del proyecto SRA.")
 else:
-    print(f"Clean SRR IDs: {srr_ids}")
+    print(f"IDs SRR encontrados: {srr_ids}")
 
-# ===============================
-# 2. DOWNLOAD SRR FILES AND CONVERT TO FASTQ
-# ===============================
+# ============================================================================
+# 2. DESCARGA Y CONVERSIÓN DE LOS ARCHIVOS SRR A FASTQ
+# ============================================================================
 for srr in srr_ids:
-    print(f"\nDownloading SRR {srr} to raw_sra...")
-    subprocess.run([prefetch_path, srr, "-O", dirs["raw_sra"]], check=True)
+    print(f"\n  Descargando SRR {srr} a {dirs['raw_sra']} ...")
 
-    print(f"Converting {srr} to FASTQ...")
-    subprocess.run([fasterq_dump_path, srr, "--split-files", "-O", dirs["fastq"]], check=True)
-
-# ===============================
-# 3. DOWNLOAD GENOME ASSEMBLY
-# ===============================
-print("\nDownloading genome assembly and annotation...")
-fasta_out = os.path.join(dirs["genome"], "genome.fna.gz")
-gff_out = os.path.join(dirs["genome"], "genome.gff.gz")
-
-# Download FASTA
-if not os.path.exists(fasta_out):
-    print("Downloading genome FASTA...")
-    urllib.request.urlretrieve(fasta_url, fasta_out)
-else:
-    print("Genome FASTA already exists, skipping.")
-
-# Download GFF
-if not os.path.exists(gff_out):
-    print("Downloading genome GFF...")
-    urllib.request.urlretrieve(gff_url, gff_out)
-else:
-    print("Genome GFF already exists, skipping.")
-
-# ===============================
-# 4. UNZIP GENOME FILES
-# ===============================
-def unzip_gz(file_path):
-    out_file = file_path.replace(".gz","")
-    if not os.path.exists(out_file):
-        print(f"Unzipping {file_path}...")
-        with gzip.open(file_path, 'rb') as f_in:
-            with open(out_file, 'wb') as f_out:
-                shutil.copyfileobj(f_in, f_out)
+    # Saltar descarga si el archivo ya existe
+    local_sra = os.path.join(dirs["raw_sra"], f"{srr}.sra")
+    if not os.path.exists(local_sra):
+        subprocess.run([prefetch_path, srr, "-O", dirs["raw_sra"]], check=True)
     else:
-        print(f"{out_file} already exists, skipping unzip.")
+        print(f"  El archivo {local_sra} ya existe — se omite la descarga.")
 
-unzip_gz(fasta_out)
-unzip_gz(gff_out)
+    # Convertir a FASTQ (solo si no se ha hecho antes)
+    fq1 = os.path.join(dirs["fastq"], f"{srr}_1.fastq")
+    fq2 = os.path.join(dirs["fastq"], f"{srr}_2.fastq")
+    if not (os.path.exists(fq1) or os.path.exists(fq2)):
+        print(f"  Convirtiendo {srr} a formato FASTQ ...")
+        subprocess.run(
+            [fasterq_dump_path, srr, "--split-files", "-O", dirs["fastq"]],
+            check=True,
+        )
+    else:
+        print(f"  Los archivos FASTQ ya existen — se omite la conversión.")
 
-print("\nAll downloads and conversions completed successfully!")
+# ============================================================================
+# 3. DESCUBRIR Y DESCARGAR EL GENOMA DE REFERENCIA
+# ============================================================================
+print("\n Buscando el mejor ensamblaje disponible (RefSeq preferido)...")
+
+meta, fasta_out, gff_out = fetch_reference_package(
+    organism_query=organism_query,
+    strain=strain_hint,
+    bioproject=bioproject_hint,
+    out_dir=dirs["genome"],
+    prefer_refseq=True,
+    also_download=(),    # Ejemplo: ("protein","cds") si se requiere
+    check_md5=False,     # Cambiar a True si deseas verificar MD5
+)
+
+print("\n Ensamblaje seleccionado:")
+print(f"  Accession:       {meta['accession']}")
+print(f"  Organismo:       {meta['organism']}")
+print(f"  Nombre:          {meta['assembly_name']}")
+print(f"  Estado:          {meta['assembly_status']}")
+print(f"  Categoría RefSeq:{meta['refseq_category']}")
+print(f"  FTP:             {meta['ftp']}")
+
+# ============================================================================
+# 4. DESCOMPRIMIR LOS ARCHIVOS DEL GENOMA
+# ============================================================================
+def descomprimir_gz(ruta_archivo):
+    """Descomprime archivos .gz (FASTA o GFF)."""
+    salida = ruta_archivo.replace(".gz", "")
+    if not os.path.exists(salida):
+        print(f"Descomprimiendo {ruta_archivo} ...")
+        with gzip.open(ruta_archivo, "rb") as f_in, open(salida, "wb") as f_out:
+            shutil.copyfileobj(f_in, f_out)
+    else:
+        print(f"{salida} ya existe — se omite la descompresión.")
+    return salida
+
+
+fasta_unzip = descomprimir_gz(fasta_out)
+gff_unzip = descomprimir_gz(gff_out)
+
+print(f"\n Genoma y anotaciones listos:\n  FASTA: {fasta_unzip}\n  GFF:   {gff_unzip}")
+
+# ============================================================================
+# 5. FINALIZACIÓN DEL PIPELINE
+# ============================================================================
+print("\n Descargas y conversiones completadas exitosamente.")
+print(f"Archivos almacenados en: {os.path.abspath(output_dir)}")

--- a/src/descarga_genoma_referencia.py
+++ b/src/descarga_genoma_referencia.py
@@ -1,0 +1,379 @@
+"""
+Descarga de genoma de referencia desde NCBI Assembly (estándar reproducible)
+
+Uso típico desde otro script:
+
+    from descarga_genoma_referencia import fetch_reference_package
+
+    meta, fasta, gff = fetch_reference_package(
+        organism_query="Klebsiella sp. AQSCr",
+        strain="AQSCr",
+        bioproject=None,
+        out_dir="results/genome",
+        prefer_refseq=True,
+        also_download=("protein", "cds"),  # opcional
+        check_md5=True                       # opcional
+    )
+
+Requisitos:
+    - biopython
+
+Notas:
+    - Este módulo consulta la base de datos Assembly (no nuccore) y prioriza RefSeq (GCF_) y
+      ensamblajes con estatus "Complete Genome"/"Chromosome".
+    - Descarga *_genomic.fna.gz y *_genomic.gff.gz (mínimo reproducible), además de protein/cds si se pide.
+    - Escribe un archivo ASSEMBLY_PROVENANCE.txt con metadatos para trazabilidad.
+"""
+
+from __future__ import annotations
+from typing import Dict, List, Optional, Tuple
+
+import datetime
+import os
+import re
+import urllib.request
+from ftplib import FTP
+from urllib.parse import urlparse
+
+from Bio import Entrez
+
+# ──────────────────────────────────────────────────────────────────────────────
+# CONFIGURACIÓN GLOBAL
+# ──────────────────────────────────────────────────────────────────────────────
+# Sustituye por un correo real para cumplir políticas de NCBI
+Entrez.email = os.environ.get("NCBI_EMAIL", "you@example.com")
+
+# ──────────────────────────────────────────────────────────────────────────────
+# UTILIDADES DE DESCARGA
+# ──────────────────────────────────────────────────────────────────────────────
+
+def _list_ftp_dir(ftp_url: str) -> List[str]:
+    """Lista los archivos en el directorio del ensamblaje usando FTP.
+
+    Acepta ftp:// o https://, internamente convierte a FTP.
+    """
+    parsed = urlparse(ftp_url.replace("https://", "ftp://"))
+    ftp_server, ftp_path = parsed.hostname, parsed.path
+    if not ftp_server or not ftp_path:
+        raise ValueError(f"URL FTP inválida: {ftp_url}")
+
+    ftp = FTP(ftp_server)
+    ftp.login()  # anónimo
+    try:
+        ftp.cwd(ftp_path)
+        files = ftp.nlst()
+    finally:
+        try:
+            ftp.quit()
+        except Exception:
+            pass
+    return files
+
+
+def _download_file(url: str, out_path: str) -> None:
+    os.makedirs(os.path.dirname(out_path), exist_ok=True)
+    urllib.request.urlretrieve(url, out_path)
+
+
+def _parse_md5_file(lines: List[str]) -> Dict[str, str]:
+    """Parsea el formato habitual de md5checksums.txt (md5  filename)."""
+    md5map: Dict[str, str] = {}
+    for line in lines:
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        # Ejemplo: d41d8cd98f00b204e9800998ecf8427e  GCF_XXXX_genomic.fna.gz
+        m = re.match(r"^([0-9a-fA-F]{32})\s+\*?(.+)$", line)
+        if m:
+            md5, fname = m.group(1).lower(), m.group(2).strip()
+            md5map[fname] = md5
+    return md5map
+
+
+def _md5sum(path: str) -> str:
+    import hashlib
+    h = hashlib.md5()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# SELECCIÓN DE ENSAMBLAJE EN NCBI ASSEMBLY
+# ──────────────────────────────────────────────────────────────────────────────
+
+def _score_assembly(doc) -> Tuple[int, int, int, datetime.datetime]:
+    """Asigna una puntuación objetiva a un ensamblaje.
+
+    Criterios (en orden):
+      1) RefSeq_category: reference > representative > none
+      2) AssemblyStatus: Complete Genome > Chromosome > Scaffold > Contig
+      3) Namespace: GCF_ (RefSeq) > GCA_ (GenBank)
+      4) Fecha de liberación (más nuevo mejor)
+    """
+    refcat = (doc.get("RefSeq_category") or "").lower()
+    ref_score = {"reference genome": 3, "representative genome": 2}.get(refcat, 0)
+
+    status = (doc.get("AssemblyStatus") or "").lower()
+    lvl_score = {"complete genome": 4, "chromosome": 3, "scaffold": 2, "contig": 1}.get(status, 0)
+
+    acc = doc.get("AssemblyAccession", "")
+    is_refseq = 1 if acc.startswith("GCF_") else 0
+
+    # fecha tipo "2020/09/28"
+    try:
+        dt = datetime.datetime.strptime(doc.get("AsmReleaseDate_GenBank", "1900/01/01"), "%Y/%m/%d")
+    except Exception:
+        dt = datetime.datetime(1900, 1, 1)
+    return (ref_score, lvl_score, is_refseq, dt)
+
+
+def find_best_assembly(
+    organism_query: str,
+    strain: Optional[str] = None,
+    bioproject: Optional[str] = None,
+    max_hits: int = 100,
+    prefer_refseq: bool = True,
+) -> Dict[str, str]:
+    """Busca y selecciona el mejor ensamblaje en NCBI Assembly.
+
+    Retorna un diccionario con:
+      - accession, ftp, organism, assembly_name, assembly_status,
+        refseq_category, taxid, bioproject
+    """
+    # Construir query
+    terms = [organism_query, "latest[filter]"]
+    if bioproject:
+        terms.append(f"{bioproject}[BioProject]")
+    q = " AND ".join(terms)
+
+    # Buscar IDs
+    h = Entrez.esearch(db="assembly", term=q, retmax=max_hits)
+    es = Entrez.read(h)
+    h.close()
+    ids = es.get("IdList", [])
+
+    if not ids:
+        # reintentar más laxo
+        h = Entrez.esearch(db="assembly", term=organism_query, retmax=max_hits)
+        es = Entrez.read(h)
+        h.close()
+        ids = es.get("IdList", [])
+        if not ids:
+            raise RuntimeError(f"No se encontraron ensamblajes para: {organism_query}")
+
+    # Resumen completo
+    h = Entrez.esummary(db="assembly", id=",".join(ids), report="full")
+    recs = Entrez.read(h)
+    h.close()
+    docs = recs["DocumentSummarySet"]["DocumentSummary"]
+
+    # Filtro opcional por strain
+    if strain:
+        s = strain.lower()
+        def has_strain(d) -> bool:
+            fields = [
+                d.get("SpeciesName", ""),
+                d.get("AssemblyName", ""),
+                d.get("Organism", ""),
+                d.get("Biosource", ""),
+                d.get("SubmitterOrganization", ""),
+                d.get("WGSProject", ""),
+            ]
+            return any(s in (x or "").lower() for x in fields)
+        cand = [d for d in docs if has_strain(d)]
+        if cand:
+            docs = cand
+
+    # Preferir RefSeq si está disponible
+    if prefer_refseq:
+        refseq_docs = [d for d in docs if (d.get("AssemblyAccession", "").startswith("GCF_"))]
+        if refseq_docs:
+            docs = refseq_docs
+
+    # Elegir el mejor según puntuación
+    best = max(docs, key=_score_assembly)
+
+    acc = best.get("AssemblyAccession")
+    ftp = best.get("FtpPath_RefSeq") or best.get("FtpPath_GenBank")
+    if not ftp:
+        raise RuntimeError(f"El ensamblaje {acc} no tiene ruta FTP en el resumen.")
+
+    return {
+        "accession": acc,
+        "ftp": ftp.replace("ftp://", "https://"),  # permite descarga vía HTTPS
+        "organism": best.get("Organism"),
+        "assembly_name": best.get("AssemblyName"),
+        "assembly_status": best.get("AssemblyStatus"),
+        "refseq_category": best.get("RefSeq_category") or "None",
+        "taxid": best.get("Taxid"),
+        "bioproject": best.get("BioprojectAccn"),
+    }
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# DESCARGA DE PAQUETE DE REFERENCIA
+# ──────────────────────────────────────────────────────────────────────────────
+
+def download_reference_genome(
+    ftp_url: str,
+    output_dir: str,
+    also_download: Tuple[str, ...] = (),  # e.g., ("protein", "cds")
+    check_md5: bool = False,
+) -> Dict[str, str]:
+    """Descarga archivos clave del ensamblaje (FASTA, GFF y opcionales) desde el FTP.
+
+    also_download: tupla con elementos de {"protein", "cds", "gbff"}
+    check_md5: si True, intenta verificar checksum con md5checksums.txt
+
+    Retorna un dict con rutas locales descargadas.
+    """
+    files = _list_ftp_dir(ftp_url)
+
+    required = {
+        "fna": next((f for f in files if f.endswith("_genomic.fna.gz")), None),
+        "gff": next((f for f in files if f.endswith("_genomic.gff.gz")), None),
+    }
+    if not required["fna"]:
+        raise RuntimeError("No se encontró *_genomic.fna.gz en el directorio del ensamblaje.")
+    if not required["gff"]:
+        raise RuntimeError("No se encontró *_genomic.gff.gz en el directorio del ensamblaje.")
+
+    optional_map = {
+        "protein": next((f for f in files if f.endswith("_protein.faa.gz")), None),
+        "cds": next((f for f in files if f.endswith("_cds_from_genomic.fna.gz")), None),
+        "gbff": next((f for f in files if f.endswith("_genomic.gbff.gz")), None),
+        "md5": next((f for f in files if f.endswith("md5checksums.txt")), None),
+    }
+
+    os.makedirs(output_dir, exist_ok=True)
+
+    def build(url_base: str, fname: str) -> Tuple[str, str]:
+        return (f"{url_base.rstrip('/')}/{fname}", os.path.join(output_dir, fname))
+
+    downloaded: Dict[str, str] = {}
+
+    # Descargas obligatorias
+    fna_url, fna_out = build(ftp_url, required["fna"]) ; _download_file(fna_url, fna_out)
+    gff_url, gff_out = build(ftp_url, required["gff"]) ; _download_file(gff_url, gff_out)
+    downloaded["fasta"] = fna_out
+    downloaded["gff"] = gff_out
+
+    # Descargas opcionales
+    if "protein" in also_download and optional_map["protein"]:
+        u, o = build(ftp_url, optional_map["protein"]) ; _download_file(u, o)
+        downloaded["protein"] = o
+    if "cds" in also_download and optional_map["cds"]:
+        u, o = build(ftp_url, optional_map["cds"]) ; _download_file(u, o)
+        downloaded["cds"] = o
+    if "gbff" in also_download and optional_map["gbff"]:
+        u, o = build(ftp_url, optional_map["gbff"]) ; _download_file(u, o)
+        downloaded["gbff"] = o
+
+    # Verificación de MD5 (opcional)
+    if check_md5 and optional_map["md5"]:
+        md5_url, md5_out = build(ftp_url, optional_map["md5"]) ; _download_file(md5_url, md5_out)
+        with open(md5_out, "r", encoding="utf-8", errors="ignore") as f:
+            md5map = _parse_md5_file(f.readlines())
+        for label, path in list(downloaded.items()):
+            fname = os.path.basename(path)
+            if fname in md5map:
+                calc = _md5sum(path)
+                if calc.lower() != md5map[fname].lower():
+                    raise RuntimeError(f"MD5 no coincide para {fname}: {calc} != {md5map[fname]}")
+
+    return downloaded
+
+
+def _write_provenance(meta: Dict[str, str], out_dir: str) -> None:
+    os.makedirs(out_dir, exist_ok=True)
+    with open(os.path.join(out_dir, "ASSEMBLY_PROVENANCE.txt"), "w", encoding="utf-8") as f:
+        for k, v in meta.items():
+            f.write(f"{k}: {v}\n")
+
+
+def fetch_reference_package(
+    organism_query: str,
+    strain: Optional[str] = None,
+    bioproject: Optional[str] = None,
+    out_dir: str = "results/genome",
+    prefer_refseq: bool = True,
+    also_download: Tuple[str, ...] = (),
+    check_md5: bool = False,
+) -> Tuple[Dict[str, str], str, str]:
+    """Descubre el mejor ensamblaje y descarga FASTA+GFF (y opcionales).
+
+    Retorna (meta, fasta_path, gff_path)
+    """
+    meta = find_best_assembly(
+        organism_query=organism_query,
+        strain=strain,
+        bioproject=bioproject,
+        prefer_refseq=prefer_refseq,
+    )
+
+    downloaded = download_reference_genome(
+        ftp_url=meta["ftp"],
+        output_dir=out_dir,
+        also_download=also_download,
+        check_md5=check_md5,
+    )
+
+    _write_provenance(meta, out_dir)
+
+    return meta, downloaded["fasta"], downloaded["gff"]
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# MODO STANDALONE
+# ──────────────────────────────────────────────────────────────────────────────
+if __name__ == "__main__":
+    import argparse
+    import textwrap
+
+    parser = argparse.ArgumentParser(
+        description="Descubre y descarga el genoma de referencia (FASTA+GFF) desde NCBI Assembly",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=textwrap.dedent(
+            """
+            Ejemplos:
+              python descarga_genoma_referencia.py -q "Klebsiella sp. AQSCr" -s AQSCr -o results/genome
+              python descarga_genoma_referencia.py -q "Klebsiella pneumoniae" --bioproject PRJNA341863 \
+                     --also protein cds --check-md5
+            """
+        ),
+    )
+    parser.add_argument("-q", "--organism-query", required=True, help="Consulta del organismo (p.ej., 'Klebsiella sp. AQSCr')")
+    parser.add_argument("-s", "--strain", default=None, help="Cadena/cepa para filtrar (opcional)")
+    parser.add_argument("--bioproject", default=None, help="PRJNA... para restringir (opcional)")
+    parser.add_argument("-o", "--out-dir", default="results/genome", help="Directorio de salida")
+    parser.add_argument("--no-refseq", action="store_true", help="No preferir RefSeq (GCF_)")
+    parser.add_argument("--also", nargs="*", default=(), choices=["protein", "cds", "gbff"], help="Descargas adicionales")
+    parser.add_argument("--check-md5", action="store_true", help="Verificar checksums MD5 si está disponible")
+
+    args = parser.parse_args()
+
+    meta, fasta, gff = fetch_reference_package(
+        organism_query=args.organism_query,
+        strain=args.strain,
+        bioproject=args.bioproject,
+        out_dir=args.out_dir,
+        prefer_refseq=not args.no_refseq,
+        also_download=tuple(args.also),
+        check_md5=args.check_md5,
+    )
+
+    print("\n Ensamblaje seleccionado:")
+    print(f"  Accession:       {meta['accession']}")
+    print(f"  Organism:        {meta['organism']}")
+    print(f"  Assembly name:   {meta['assembly_name']}")
+    print(f"  Status:          {meta['assembly_status']}")
+    print(f"  RefSeq category: {meta['refseq_category']}")
+    print(f"  FTP:             {meta['ftp']}")
+    print("\nArchivos descargados:")
+    print(f"  FASTA: {fasta}")
+    print(f"  GFF:   {gff}")
+    if args.also:
+        print("  Extra: " + ", ".join(args.also))
+    print("\nProvenance: ASSEMBLY_PROVENANCE.txt en el directorio de salida")

--- a/src/descarga_genoma_referencia.py
+++ b/src/descarga_genoma_referencia.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 Descarga de genoma de referencia desde NCBI Assembly (estándar reproducible)
 
@@ -12,7 +13,7 @@ Uso típico desde otro script:
         out_dir="results/genome",
         prefer_refseq=True,
         also_download=("protein", "cds"),  # opcional
-        check_md5=True                       # opcional
+        check_md5=True                     # opcional
     )
 
 Requisitos:
@@ -31,73 +32,69 @@ from typing import Dict, List, Optional, Tuple
 import datetime
 import os
 import re
+import time
+import hashlib
 import urllib.request
-from ftplib import FTP
-from urllib.parse import urlparse
+from urllib.error import HTTPError, URLError
 
 from Bio import Entrez
 
 # ──────────────────────────────────────────────────────────────────────────────
 # CONFIGURACIÓN GLOBAL
 # ──────────────────────────────────────────────────────────────────────────────
-# Sustituye por un correo real para cumplir políticas de NCBI
-Entrez.email = os.environ.get("NCBI_EMAIL", "you@example.com")
+# Sustituye por un correo real para cumplir políticas de NCBI (o exporta NCBI_EMAIL)
+Entrez.email = os.environ.get("NCBI_EMAIL", "marinams@lcg.unam.mx")
+# Soporte opcional para mayor cuota de peticiones (exporta NCBI_API_KEY si la tienes)
+_api_key = os.environ.get("NCBI_API_KEY")
+if _api_key:
+    Entrez.api_key = _api_key
 
 # ──────────────────────────────────────────────────────────────────────────────
-# UTILIDADES DE DESCARGA
+# UTILIDADES: HTTP con reintentos, MD5, parseo de md5checksums.txt
 # ──────────────────────────────────────────────────────────────────────────────
 
-def _list_ftp_dir(ftp_url: str) -> List[str]:
-    """Lista los archivos en el directorio del ensamblaje usando FTP.
-
-    Acepta ftp:// o https://, internamente convierte a FTP.
-    """
-    parsed = urlparse(ftp_url.replace("https://", "ftp://"))
-    ftp_server, ftp_path = parsed.hostname, parsed.path
-    if not ftp_server or not ftp_path:
-        raise ValueError(f"URL FTP inválida: {ftp_url}")
-
-    ftp = FTP(ftp_server)
-    ftp.login()  # anónimo
-    try:
-        ftp.cwd(ftp_path)
-        files = ftp.nlst()
-    finally:
+def _http_get(url: str, timeout: int = 60, tries: int = 5, backoff: float = 0.7) -> bytes:
+    """GET con reintentos exponenciales (429/5xx/errores de red)."""
+    last_exc = None
+    for i in range(tries):
         try:
-            ftp.quit()
-        except Exception:
-            pass
-    return files
+            with urllib.request.urlopen(url, timeout=timeout) as r:
+                return r.read()
+        except (HTTPError, URLError, TimeoutError) as e:
+            last_exc = e
+            time.sleep(backoff * (2 ** i))
+    raise last_exc
 
-
-def _download_file(url: str, out_path: str) -> None:
+def _download_file(url: str, out_path: str, overwrite: bool = False) -> None:
+    """Descarga con reintentos; idempotente por defecto (no sobrescribe si existe con tamaño>0)."""
     os.makedirs(os.path.dirname(out_path), exist_ok=True)
-    urllib.request.urlretrieve(url, out_path)
+    if (not overwrite) and os.path.exists(out_path) and os.path.getsize(out_path) > 0:
+        return
+    data = _http_get(url)
+    with open(out_path, "wb") as f:
+        f.write(data)
 
-
-def _parse_md5_file(lines: List[str]) -> Dict[str, str]:
-    """Parsea el formato habitual de md5checksums.txt (md5  filename)."""
+def _parse_md5_file_text(md5_text: str) -> Dict[str, str]:
+    """Parses md5checksums.txt (formato: <md5> <espacio> <ruta/archivo>)."""
     md5map: Dict[str, str] = {}
-    for line in lines:
-        line = line.strip()
-        if not line or line.startswith("#"):
+    for ln in md5_text.splitlines():
+        ln = ln.strip()
+        if not ln or ln.startswith("#"):
             continue
-        # Ejemplo: d41d8cd98f00b204e9800998ecf8427e  GCF_XXXX_genomic.fna.gz
-        m = re.match(r"^([0-9a-fA-F]{32})\s+\*?(.+)$", line)
-        if m:
-            md5, fname = m.group(1).lower(), m.group(2).strip()
-            md5map[fname] = md5
+        parts = ln.split()
+        if len(parts) >= 2:
+            md5 = parts[0].lower()
+            fname = parts[-1].split("/")[-1]  # tomar nombre, ignorar path
+            if len(md5) == 32 and fname:
+                md5map[fname] = md5
     return md5map
 
-
 def _md5sum(path: str) -> str:
-    import hashlib
     h = hashlib.md5()
     with open(path, "rb") as f:
-        for chunk in iter(lambda: f.read(8192), b""):
+        for chunk in iter(lambda: f.read(1 << 20), b""):
             h.update(chunk)
     return h.hexdigest()
-
 
 # ──────────────────────────────────────────────────────────────────────────────
 # SELECCIÓN DE ENSAMBLAJE EN NCBI ASSEMBLY
@@ -128,6 +125,19 @@ def _score_assembly(doc) -> Tuple[int, int, int, datetime.datetime]:
         dt = datetime.datetime(1900, 1, 1)
     return (ref_score, lvl_score, is_refseq, dt)
 
+def _entrez_read_with_retry(fn, max_tries: int = 5, base_sleep: float = 0.5):
+    """Wrapper de Entrez.read con reintentos/backoff."""
+    last_exc = None
+    for i in range(max_tries):
+        try:
+            h = fn()
+            rec = Entrez.read(h)
+            h.close()
+            return rec
+        except Exception as e:
+            last_exc = e
+            time.sleep(base_sleep * (2 ** i))
+    raise last_exc
 
 def find_best_assembly(
     organism_query: str,
@@ -148,25 +158,19 @@ def find_best_assembly(
         terms.append(f"{bioproject}[BioProject]")
     q = " AND ".join(terms)
 
-    # Buscar IDs
-    h = Entrez.esearch(db="assembly", term=q, retmax=max_hits)
-    es = Entrez.read(h)
-    h.close()
+    # Buscar IDs (con reintentos)
+    es = _entrez_read_with_retry(lambda: Entrez.esearch(db="assembly", term=q, retmax=max_hits))
     ids = es.get("IdList", [])
 
     if not ids:
         # reintentar más laxo
-        h = Entrez.esearch(db="assembly", term=organism_query, retmax=max_hits)
-        es = Entrez.read(h)
-        h.close()
+        es = _entrez_read_with_retry(lambda: Entrez.esearch(db="assembly", term=organism_query, retmax=max_hits))
         ids = es.get("IdList", [])
         if not ids:
             raise RuntimeError(f"No se encontraron ensamblajes para: {organism_query}")
 
     # Resumen completo
-    h = Entrez.esummary(db="assembly", id=",".join(ids), report="full")
-    recs = Entrez.read(h)
-    h.close()
+    recs = _entrez_read_with_retry(lambda: Entrez.esummary(db="assembly", id=",".join(ids), report="full"))
     docs = recs["DocumentSummarySet"]["DocumentSummary"]
 
     # Filtro opcional por strain
@@ -202,7 +206,7 @@ def find_best_assembly(
 
     return {
         "accession": acc,
-        "ftp": ftp.replace("ftp://", "https://"),  # permite descarga vía HTTPS
+        "ftp": ftp.replace("ftp://", "https://"),  # descarga por HTTPS
         "organism": best.get("Organism"),
         "assembly_name": best.get("AssemblyName"),
         "assembly_status": best.get("AssemblyStatus"),
@@ -211,87 +215,72 @@ def find_best_assembly(
         "bioproject": best.get("BioprojectAccn"),
     }
 
-
 # ──────────────────────────────────────────────────────────────────────────────
-# DESCARGA DE PAQUETE DE REFERENCIA
+# DESCARGA DE PAQUETE DE REFERENCIA (HTTPS + md5checksums + reintentos)
 # ──────────────────────────────────────────────────────────────────────────────
 
 def download_reference_genome(
     ftp_url: str,
     output_dir: str,
-    also_download: Tuple[str, ...] = (),  # e.g., ("protein", "cds")
-    check_md5: bool = False,
+    also_download: Tuple[str, ...] = (),  # e.g., ("protein", "cds", "gbff")
+    check_md5: bool = True,
 ) -> Dict[str, str]:
-    """Descarga archivos clave del ensamblaje (FASTA, GFF y opcionales) desde el FTP.
-
-    also_download: tupla con elementos de {"protein", "cds", "gbff"}
-    check_md5: si True, intenta verificar checksum con md5checksums.txt
-
-    Retorna un dict con rutas locales descargadas.
     """
-    files = _list_ftp_dir(ftp_url)
-
-    required = {
-        "fna": next((f for f in files if f.endswith("_genomic.fna.gz")), None),
-        "gff": next((f for f in files if f.endswith("_genomic.gff.gz")), None),
-    }
-    if not required["fna"]:
-        raise RuntimeError("No se encontró *_genomic.fna.gz en el directorio del ensamblaje.")
-    if not required["gff"]:
-        raise RuntimeError("No se encontró *_genomic.gff.gz en el directorio del ensamblaje.")
-
-    optional_map = {
-        "protein": next((f for f in files if f.endswith("_protein.faa.gz")), None),
-        "cds": next((f for f in files if f.endswith("_cds_from_genomic.fna.gz")), None),
-        "gbff": next((f for f in files if f.endswith("_genomic.gbff.gz")), None),
-        "md5": next((f for f in files if f.endswith("md5checksums.txt")), None),
-    }
-
+    Descarga *_genomic.fna.gz y *_genomic.gff.gz (y opcionales) usando md5checksums.txt por HTTPS.
+    Verifica MD5 si está disponible. Idempotente por defecto.
+    Retorna dict con rutas locales: {"fasta": ..., "gff": ..., "protein": ..., "cds": ..., "gbff": ...}
+    """
     os.makedirs(output_dir, exist_ok=True)
 
-    def build(url_base: str, fname: str) -> Tuple[str, str]:
-        return (f"{url_base.rstrip('/')}/{fname}", os.path.join(output_dir, fname))
+    # Asegurar HTTPS y preparar índice md5
+    base = ftp_url.replace("ftp://", "https://").rstrip("/")
+    md5_url = f"{base}/md5checksums.txt"
+
+    md5_text = _http_get(md5_url).decode("utf-8", "ignore")
+    md5map = _parse_md5_file_text(md5_text)
+
+    # Derivar nombres esperados a partir del prefijo del directorio
+    prefix = os.path.basename(base)  # p.ej., GCF_008452795.1_ASM845279v1
+    required_fna = f"{prefix}_genomic.fna.gz"
+    required_gff = f"{prefix}_genomic.gff.gz"
+
+    if required_fna not in md5map:
+        raise RuntimeError(f"No se encontró {required_fna} en md5checksums.txt")
+    if required_gff not in md5map:
+        raise RuntimeError(f"No se encontró {required_gff} en md5checksums.txt")
+
+    to_get: Dict[str, str] = {
+        "fasta": required_fna,
+        "gff":   required_gff,
+    }
+    optional_candidates = {
+        "protein": f"{prefix}_protein.faa.gz",
+        "cds":     f"{prefix}_cds_from_genomic.fna.gz",
+        "gbff":    f"{prefix}_genomic.gbff.gz",
+    }
+    for label, fname in optional_candidates.items():
+        if label in also_download and fname in md5map:
+            to_get[label] = fname  # solo si existe en este ensamblaje
 
     downloaded: Dict[str, str] = {}
-
-    # Descargas obligatorias
-    fna_url, fna_out = build(ftp_url, required["fna"]) ; _download_file(fna_url, fna_out)
-    gff_url, gff_out = build(ftp_url, required["gff"]) ; _download_file(gff_url, gff_out)
-    downloaded["fasta"] = fna_out
-    downloaded["gff"] = gff_out
-
-    # Descargas opcionales
-    if "protein" in also_download and optional_map["protein"]:
-        u, o = build(ftp_url, optional_map["protein"]) ; _download_file(u, o)
-        downloaded["protein"] = o
-    if "cds" in also_download and optional_map["cds"]:
-        u, o = build(ftp_url, optional_map["cds"]) ; _download_file(u, o)
-        downloaded["cds"] = o
-    if "gbff" in also_download and optional_map["gbff"]:
-        u, o = build(ftp_url, optional_map["gbff"]) ; _download_file(u, o)
-        downloaded["gbff"] = o
-
-    # Verificación de MD5 (opcional)
-    if check_md5 and optional_map["md5"]:
-        md5_url, md5_out = build(ftp_url, optional_map["md5"]) ; _download_file(md5_url, md5_out)
-        with open(md5_out, "r", encoding="utf-8", errors="ignore") as f:
-            md5map = _parse_md5_file(f.readlines())
-        for label, path in list(downloaded.items()):
-            fname = os.path.basename(path)
-            if fname in md5map:
-                calc = _md5sum(path)
-                if calc.lower() != md5map[fname].lower():
-                    raise RuntimeError(f"MD5 no coincide para {fname}: {calc} != {md5map[fname]}")
+    for label, fname in to_get.items():
+        url = f"{base}/{fname}"
+        out_path = os.path.join(output_dir, fname)
+        _download_file(url, out_path, overwrite=False)
+        if check_md5:
+            calc = _md5sum(out_path)
+            exp = md5map.get(fname, "").lower()
+            if exp and calc.lower() != exp:
+                raise RuntimeError(f"MD5 no coincide para {fname}: {calc} != {exp}")
+        downloaded[label] = out_path
 
     return downloaded
-
 
 def _write_provenance(meta: Dict[str, str], out_dir: str) -> None:
     os.makedirs(out_dir, exist_ok=True)
     with open(os.path.join(out_dir, "ASSEMBLY_PROVENANCE.txt"), "w", encoding="utf-8") as f:
         for k, v in meta.items():
             f.write(f"{k}: {v}\n")
-
 
 def fetch_reference_package(
     organism_query: str,
@@ -300,7 +289,7 @@ def fetch_reference_package(
     out_dir: str = "results/genome",
     prefer_refseq: bool = True,
     also_download: Tuple[str, ...] = (),
-    check_md5: bool = False,
+    check_md5: bool = True,
 ) -> Tuple[Dict[str, str], str, str]:
     """Descubre el mejor ensamblaje y descarga FASTA+GFF (y opcionales).
 
@@ -321,12 +310,10 @@ def fetch_reference_package(
     )
 
     _write_provenance(meta, out_dir)
-
     return meta, downloaded["fasta"], downloaded["gff"]
 
-
 # ──────────────────────────────────────────────────────────────────────────────
-# MODO STANDALONE
+# MODO STANDALONE (CLI)
 # ──────────────────────────────────────────────────────────────────────────────
 if __name__ == "__main__":
     import argparse


### PR DESCRIPTION
Este PR actualiza Pipeline_2.0 y descarga_genoma_referencia.py para:
- Usar descarga HTTPS y verificación MD5 desde NCBI Assembly
- Garantizar genoma RefSeq completo (GCF_)
- Guardar metadatos en ASSEMBLY_PROVENANCE.txt
- Hacer el flujo SRA→FASTQ idempotente
- Mantener estructura estándar de salida {raw_sra, fastq, genome}